### PR TITLE
Refactor model naming to operator/model format

### DIFF
--- a/server/archive/prompt_generator_before_agent.py
+++ b/server/archive/prompt_generator_before_agent.py
@@ -49,7 +49,7 @@ def add_image_to_prompt(model_name, params, image):
 
 def add_websearch_to_prompt(params, query):
     from archive.websearch import websearch_main
-    from handlers.model_utils import get_model_instance_by_operator
+    from handlers.model_utils import get_model_instance
 
     prompt = [
         (
@@ -77,9 +77,9 @@ def add_websearch_to_prompt(params, query):
         ),
         ("human", "User query:{query}"),
     ]
-    openai = get_model_instance_by_operator(
-        config.default_operator,
-        config.default_base_model,
+    openai = get_model_instance(
+        model_name=config.default_base_model,
+        operator_name=config.default_operator,
     )
     websearch_queries = openai.invoke(
         ChatPromptTemplate(prompt).invoke({"query": query})

--- a/server/handlers/chat_handlers.py
+++ b/server/handlers/chat_handlers.py
@@ -4,7 +4,7 @@ from utils.log import output_log
 from utils.mysql_connect import MysqlConnect
 from services.response_formatter import response_formatter_main
 import services.prompt_generator as prompt_generator
-from handlers.model_utils import get_model_instance_by_operator
+from handlers.model_utils import get_model_instance
 from fastapi.responses import StreamingResponse, JSONResponse
 import json
 from typing import AsyncIterator
@@ -240,8 +240,7 @@ def create_batch_response(
             content={"error": "Invalid messages format."},
             status_code=400,
         )
-    base_model_ins = get_model_instance_by_operator(
-        chat_config.operator,
+    base_model_ins = get_model_instance(
         chat_config.base_model,
     )
     if base_model_ins is None:

--- a/server/handlers/model_handlers.py
+++ b/server/handlers/model_handlers.py
@@ -51,9 +51,9 @@ def refresh_models():
     responses = server_models.copy()
     for operator in get_all_operators():
         try:
-            from handlers.model_utils import get_model_instance_by_operator
+            from handlers.model_utils import get_model_instance
 
-            model_ins = get_model_instance_by_operator(operator.operator)
+            model_ins = get_model_instance(model_name="", operator_name=operator.operator)
             if model_ins is None:
                 continue
             models = model_ins.list_models()
@@ -63,11 +63,13 @@ def refresh_models():
             )
             continue
         for model in models.split("\n"):
+            model_name = f"{operator.operator}/{model}"
             server_match = next(
                 (
                     server_model
                     for server_model in server_models
-                    if server_model.model_name == model and server_model.operator == operator.operator
+                    if server_model.model_name == model_name
+                    and server_model.operator == operator.operator
                 ),
                 None,
             )
@@ -77,7 +79,7 @@ def refresh_models():
             else:
                 new_model = ModelConfig(
                     operator=operator.operator,
-                    model_name=model,
+                    model_name=model_name,
                     isAvailable=False,
                     reasoning_effect="not a reasoning model",
                 )

--- a/server/handlers/model_utils.py
+++ b/server/handlers/model_utils.py
@@ -6,7 +6,23 @@ import os
 import pickle
 
 
-def get_model_instance_by_operator(operator_name, model_name: str = ""):
+def get_model_instance(model_name: str = "", operator_name: str = None):
+    real_model_name = model_name
+    if operator_name is None:
+        if "/" in model_name:
+            operator_name, real_model_name = model_name.split("/", 1)
+        else:
+            output_log(
+                f"Operator not provided and not found in model name: {model_name}",
+                "error",
+            )
+            return None
+
+    if "/" not in model_name and operator_name:
+        full_model_name = f"{operator_name}/{model_name}"
+    else:
+        full_model_name = model_name
+
     operator = get_operator(operator_name)
     base_model_ins = None
     if operator is None:
@@ -23,8 +39,8 @@ def get_model_instance_by_operator(operator_name, model_name: str = ""):
             api_key=operator.api_key,
             organization_id=operator.org_id,
             project_id=operator.project_id,
-            model=model_name,
-            reasoning_effect=get_reasoning_effect(model_name),
+            model=real_model_name,
+            reasoning_effect=get_reasoning_effect(full_model_name),
         )
     elif operator.runtime == "openai_completion":
         from services.chat_models.openai_completion import CustomOpenAICompletion
@@ -34,24 +50,24 @@ def get_model_instance_by_operator(operator_name, model_name: str = ""):
             api_key=operator.api_key,
             organization_id=operator.org_id,
             project_id=operator.project_id,
-            model=model_name,
-            reasoning_effect=get_reasoning_effect(model_name),
+            model=real_model_name,
+            reasoning_effect=get_reasoning_effect(full_model_name),
         )
     elif operator.runtime == "gemini":
         from services.chat_models.gemini_langchain import CustomGemini
 
         base_model_ins = CustomGemini(
             api_key=operator.api_key,
-            model=model_name,
-            reasoning_effect=get_reasoning_effect(model_name),
+            model=real_model_name,
+            reasoning_effect=get_reasoning_effect(full_model_name),
         )
     elif operator.runtime == "claude":
         from services.chat_models.claude_langchain import CustomClaude
 
         base_model_ins = CustomClaude(
             api_key=operator.api_key,
-            model=model_name,
-            reasoning_effect=get_reasoning_effect(model_name),
+            model=real_model_name,
+            reasoning_effect=get_reasoning_effect(full_model_name),
         )
     elif operator.runtime == "xai":
         from services.chat_models.xai_langchain import CustomXAIResponse
@@ -59,8 +75,8 @@ def get_model_instance_by_operator(operator_name, model_name: str = ""):
         base_model_ins = CustomXAIResponse(
             base_url=operator.endpoint,
             api_key=operator.api_key,
-            model=model_name,
-            reasoning_effect=get_reasoning_effect(model_name),
+            model=real_model_name,
+            reasoning_effect=get_reasoning_effect(full_model_name),
         )
     elif operator.runtime == "openrouter":
         from services.chat_models.openrouter_langchain import CustomOpenRouterCompletion
@@ -68,15 +84,15 @@ def get_model_instance_by_operator(operator_name, model_name: str = ""):
         base_model_ins = CustomOpenRouterCompletion(
             base_url=operator.endpoint,
             api_key=operator.api_key,
-            model=model_name,
-            reasoning_effect=get_reasoning_effect(model_name),
+            model=real_model_name,
+            reasoning_effect=get_reasoning_effect(full_model_name),
         )
     elif operator.runtime == "huggingface":
         from langchain_huggingface import ChatHuggingFace, HuggingFacePipeline
 
         os.environ["HUGGINGFACEHUB_API_TOKEN"] = operator.api_key
         llm = HuggingFacePipeline.from_model_id(
-            model_id=model_name,
+            model_id=real_model_name,
             task="text-generation",
             trust_remote_code=True,
             pipeline_kwargs=dict(
@@ -93,7 +109,18 @@ def get_model_instance_by_operator(operator_name, model_name: str = ""):
     return base_model_ins
 
 
-def get_embedding_instance_by_operator(operator_name, model_name: str = ""):
+def get_embedding_instance(model_name: str = "", operator_name: str = None):
+    real_model_name = model_name
+    if operator_name is None:
+        if "/" in model_name:
+            operator_name, real_model_name = model_name.split("/", 1)
+        else:
+            output_log(
+                f"Operator not provided and not found in model name: {model_name}",
+                "error",
+            )
+            return None
+
     operator = get_operator(operator_name)
     embedding_model_ins = None
     if operator is None:
@@ -106,10 +133,10 @@ def get_embedding_instance_by_operator(operator_name, model_name: str = ""):
         from langchain_huggingface import HuggingFaceEmbeddings
 
         if os.path.exists(
-            f"{config.huggingface_cache_dir}/{model_name.split('/')[-1]}.pickle"
+            f"{config.huggingface_cache_dir}/{real_model_name.split('/')[-1]}.pickle"
         ):
             pickle_file = open(
-                f"{config.huggingface_cache_dir}/{model_name.split('/')[-1]}.pickle",
+                f"{config.huggingface_cache_dir}/{real_model_name.split('/')[-1]}.pickle",
                 "rb",
             )
             embedding_model_ins = pickle.load(pickle_file)
@@ -118,11 +145,11 @@ def get_embedding_instance_by_operator(operator_name, model_name: str = ""):
             encode_kwargs = {"normalize_embeddings": False}
             embedding_model_ins = HuggingFaceEmbeddings(
                 cache_folder=config.huggingface_cache_dir,
-                model_name=model_name,
+                model_name=real_model_name,
                 encode_kwargs=encode_kwargs,
             )
             pickle_file = open(
-                f"{config.huggingface_cache_dir}/{model_name.split('/')[-1]}.pickle",
+                f"{config.huggingface_cache_dir}/{real_model_name.split('/')[-1]}.pickle",
                 "wb",
             )
             pickle.dump(embedding_model_ins, pickle_file)
@@ -133,13 +160,13 @@ def get_embedding_instance_by_operator(operator_name, model_name: str = ""):
         embedding_model_ins = OpenAIEmbeddings(
             base_url=operator.endpoint,
             api_key=operator.api_key,
-            model=model_name,
+            model=real_model_name,
         )
     elif operator.runtime == "gemini":
         from langchain_gemini import GeminiEmbeddings
 
         embedding_model_ins = GeminiEmbeddings(
             api_key=operator.api_key,
-            model=model_name,
+            model=real_model_name,
         )
     return embedding_model_ins

--- a/server/services/peng_agent.py
+++ b/server/services/peng_agent.py
@@ -94,12 +94,12 @@ class PengAgent:
             yield chunk
 
     async def call_model(self, state: AgentState):
-        from handlers.model_utils import get_model_instance_by_operator
+        from handlers.model_utils import get_model_instance
 
         writer = get_stream_writer()
         await self._ensure_tools()
         if not hasattr(self, "_llm_instance") or self._llm_instance is None:
-            self._llm_instance = get_model_instance_by_operator(self.operator, self.model)
+            self._llm_instance = get_model_instance(self.model)
         llm = self._llm_instance
         llm = llm.bind_tools(list(self.tools.values()))
         final_response = ""

--- a/server/services/rag/qdrant_api.py
+++ b/server/services/rag/qdrant_api.py
@@ -1,7 +1,7 @@
 from qdrant_client import QdrantClient, models
 from qdrant_client.models import VectorParams, Distance
 from langchain_qdrant import QdrantVectorStore, RetrievalMode
-from handlers.model_utils import get_embedding_instance_by_operator
+from handlers.model_utils import get_embedding_instance
 from utils.log import output_log
 from config.config import config
 
@@ -15,9 +15,9 @@ class Qdrant:
     ):
         self.client = QdrantClient(host=host, port=port)
         self.collection_name = collection_name
-        self.embedding = get_embedding_instance_by_operator(
-            operator_name=config.embedding_operator,
+        self.embedding = get_embedding_instance(
             model_name=config.embedding_model,
+            operator_name=config.embedding_operator,
         )
         if not self.client.collection_exists(collection_name):
             output_log(

--- a/server/services/rag/rag_builder.py
+++ b/server/services/rag/rag_builder.py
@@ -1,7 +1,7 @@
 from langchain_community.document_loaders import PyPDFLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from services.rag.qdrant_api import Qdrant
-from handlers.model_utils import get_embedding_instance_by_operator
+from handlers.model_utils import get_embedding_instance
 from config.config import config
 from utils.minio_connection import MinioStorage
 from utils.mysql_connect import MysqlConnect
@@ -24,9 +24,9 @@ class RagBuilder:
         self.user_name = user_name
         self.collection_name = collection_name
         self.temp_dir = tempfile.mkdtemp()
-        self.embeddings = get_embedding_instance_by_operator(
-            operator_name=config.embedding_operator,
+        self.embeddings = get_embedding_instance(
             model_name=config.embedding_model,
+            operator_name=config.embedding_operator,
         )
         self.qdrant = Qdrant(
             host=config.qdrant_host,
@@ -125,7 +125,7 @@ class RagBuilder:
         return chunks
 
     def _process_single_image(self, base64_image):
-        from handlers.model_utils import get_model_instance_by_operator
+        from handlers.model_utils import get_model_instance
 
         prompt = [
             (
@@ -141,9 +141,9 @@ class RagBuilder:
             ),
             ("human", base64_image),
         ]
-        base_model_ins = get_model_instance_by_operator(
-            config.default_operator,
-            config.default_base_model,
+        base_model_ins = get_model_instance(
+            model_name=config.default_base_model,
+            operator_name=config.default_operator,
         )
         return base_model_ins.invoke(prompt).content
 

--- a/server/services/rag/rag_usage.py
+++ b/server/services/rag/rag_usage.py
@@ -1,6 +1,6 @@
 from services.rag.qdrant_api import Qdrant
 import services.prompt_generator as prompt_generator
-from handlers.model_utils import get_model_instance_by_operator
+from handlers.model_utils import get_model_instance
 from config.config import config
 from langchain.chains.combine_documents import create_stuff_documents_chain
 from langchain.chains import create_retrieval_chain
@@ -17,9 +17,9 @@ class RagUsage:
     ):
         self.user_name = user_name
         self.collection_name = collection_name
-        self.llm = get_model_instance_by_operator(
-            config.default_operator,
-            config.default_base_model,
+        self.llm = get_model_instance(
+            model_name=config.default_base_model,
+            operator_name=config.default_operator,
         )
 
     def setup(self, prompt):

--- a/server/services/tools/web_page_tools.py
+++ b/server/services/tools/web_page_tools.py
@@ -43,9 +43,9 @@ async def deep_web_crawler(url: str) -> str:
     response = ""
     for result in results:
         if len(str(result.html)) > 1000:
-            from handlers.model_utils import get_model_instance_by_operator
+            from handlers.model_utils import get_model_instance
 
-            llm = get_model_instance_by_operator("openai", "gpt-4.1-mini")
+            llm = get_model_instance("openai/gpt-4.1-mini")
             summary = await llm.ainvoke(
                 f"Extract useful information from the following web page content do not summary or modify them:\n{result.html}"
             )

--- a/server/test/test2.py
+++ b/server/test/test2.py
@@ -11,14 +11,14 @@ load_dotenv(dotenv_path)
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR + "../"))
 
-from handlers.model_utils import get_model_instance_by_operator
+from handlers.model_utils import get_model_instance
 from langchain_core.messages import (
     SystemMessage,
     HumanMessage,
 )
 
 
-model = get_model_instance_by_operator("openai", "gpt-5-mini")
+model = get_model_instance("openai/gpt-5-mini")
 
 messages = [
     SystemMessage(content="You are a helpful assistant."),

--- a/web/src/components/ChatInterface.tsx
+++ b/web/src/components/ChatInterface.tsx
@@ -159,6 +159,10 @@ const ChatbotUI = () => {
 
   // Function to determine operator based on model name
   const getOperatorForModel = (modelName: string): string => {
+    // Check if the model name includes the operator
+    if (modelName.includes('/')) {
+      return modelName.split('/')[0];
+    }
     // Find the model in available base models
     const matchingModel = availableBaseModels.find((model) => model.model_name === modelName);
 

--- a/web/src/components/ChatInterface.tsx
+++ b/web/src/components/ChatInterface.tsx
@@ -163,11 +163,9 @@ const ChatbotUI = () => {
     if (modelName.includes('/')) {
       return modelName.split('/')[0];
     }
-    // Find the model in available base models
-    const matchingModel = availableBaseModels.find((model) => model.model_name === modelName);
 
     // Return the operator if found, or default to "openai"
-    return matchingModel?.operator || 'openai';
+    return 'openai';
   };
 
   // Tool management functions


### PR DESCRIPTION
This change updates the model naming convention to `operator/model_name` to avoid conflicts when different operators provide models with the same name. It refactors backend utilities to parse the operator from the model name and updates the frontend to handle the new format.

---
*PR created automatically by Jules for task [10819760181736826530](https://jules.google.com/task/10819760181736826530) started by @noahpengding*