### PR TITLE
feat(a11y): Add accessible labels to InputArea controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-06-03 - Chat Interface Accessibility
+**Learning:** Icon-only buttons (like send/upload) in chat interfaces often lack accessible names, making them invisible to screen readers.
+**Action:** Always check `aria-label` for buttons that rely on icons or emojis for visual meaning.

--- a/web/src/components/InputArea.tsx
+++ b/web/src/components/InputArea.tsx
@@ -139,7 +139,13 @@ export const InputArea: React.FC<InputAreaProps> = ({
             {uploadedImages.map((img, index) => (
               <div key={index} className="image-preview-container">
                 <img src={img.preview} alt="Preview" className="image-preview" />
-                <button type="button" onClick={() => handleClearImage(index)} className="clear-image-button" title="Remove image">
+                <button
+                  type="button"
+                  onClick={() => handleClearImage(index)}
+                  className="clear-image-button"
+                  title="Remove image"
+                  aria-label="Remove image"
+                >
                   ×
                 </button>
               </div>
@@ -159,6 +165,7 @@ export const InputArea: React.FC<InputAreaProps> = ({
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
             placeholder="Type your message... (Ctrl+Enter to send)"
+            aria-label="Message input"
             className="input-textarea"
             disabled={isLoading || isUploading}
             rows={1}
@@ -180,11 +187,17 @@ export const InputArea: React.FC<InputAreaProps> = ({
               onClick={() => fileInputRef.current?.click()}
               className="upload-button"
               title="Upload image"
+              aria-label="Upload image"
               disabled={isLoading || isUploading}
             >
               {isUploading ? '⏳' : '📎'}
             </button>
-            <button type="submit" className="send-button" disabled={isLoading || isUploading || (!input.trim() && uploadedImages.length === 0)}>
+            <button
+              type="submit"
+              className="send-button"
+              aria-label="Send message"
+              disabled={isLoading || isUploading || (!input.trim() && uploadedImages.length === 0)}
+            >
               ➤
             </button>
           </div>


### PR DESCRIPTION
Improved accessibility of the `InputArea` component by adding `aria-label` attributes to icon-only buttons and the message input field. This ensures that screen readers can correctly identify the purpose of these controls.

**Changes:**
- Added `aria-label="Upload image"` to the image upload button.
- Added `aria-label="Send message"` to the send message button.
- Added `aria-label="Message input"` to the message textarea.
- Added `aria-label="Remove image"` to the clear image button.

**Verification:**
- Validated changes with `bun run lint` and `bun run build`.
- Verified frontend functionality and accessibility attributes using a Playwright script that injected a JWT token to bypass login and checked for the presence of the new labels.
- Confirmed visually that the UI layout remains unchanged via screenshot.

---
*PR created automatically by Jules for task [7626420019548458703](https://jules.google.com/task/7626420019548458703) started by @noahpengding*