### PR TITLE
⚡ Bolt: Optimize N+1 queries in memory retrieval

### DIFF
--- a/server/handlers/memory_handlers.py
+++ b/server/handlers/memory_handlers.py
@@ -21,6 +21,10 @@ def get_memory(username: str = ""):
             conditions={"chat_id": chat_ids},
         )
 
+        # Sort by id to ensure deterministic order (assuming id is auto-incrementing)
+        all_user_inputs.sort(key=lambda x: x["id"])
+        all_ai_responses.sort(key=lambda x: x["id"])
+
         user_input_map = {}
         for ui in all_user_inputs:
             user_input_map.setdefault(ui["chat_id"], []).append(ui)

--- a/server/services/prompt_generator.py
+++ b/server/services/prompt_generator.py
@@ -37,6 +37,11 @@ def add_short_term_memory_to_prompt(short_term_memory, mysql_conn, model_name) -
         responses_list = mysql_conn.read_records("ai_response", conditions={"chat_id": short_term_memory})
         user_input_list = mysql_conn.read_records("user_input", conditions={"chat_id": short_term_memory})
 
+        # Sort by id to ensure deterministic order (assuming id is auto-incrementing)
+        reasonings_list.sort(key=lambda x: x["id"])
+        responses_list.sort(key=lambda x: x["id"])
+        user_input_list.sort(key=lambda x: x["id"])
+
         reasonings_map = {}
         for r in reasonings_list:
             reasonings_map.setdefault(r["chat_id"], []).append(r)

--- a/server/test/test_memory_optimization.py
+++ b/server/test/test_memory_optimization.py
@@ -1,0 +1,70 @@
+import unittest
+from services.prompt_generator import add_short_term_memory_to_prompt
+from langchain_core.messages import AIMessage, HumanMessage
+
+# Mock MysqlConnect
+class MockMysqlConnect:
+    def __init__(self, data):
+        self.data = data
+        self.call_count = 0
+
+    def read_records(self, table, conditions=None):
+        self.call_count += 1
+        records = self.data.get(table, [])
+        if conditions:
+            filtered = []
+            if isinstance(conditions.get('chat_id'), list):
+                # Batch read
+                chat_ids = conditions['chat_id']
+                for r in records:
+                    if r.get('chat_id') in chat_ids:
+                        filtered.append(r)
+            else:
+                for r in records:
+                    match = True
+                    for k, v in conditions.items():
+                        if isinstance(v, list):
+                            if r.get(k) not in v:
+                                match = False
+                                break
+                        else:
+                            if r.get(k) != v:
+                                match = False
+                                break
+                    if match:
+                        filtered.append(r)
+            return filtered
+        return records
+
+class TestMemoryOptimization(unittest.TestCase):
+    def setUp(self):
+        self.mock_data = {
+            "ai_reasoning": [
+                {"chat_id": 1, "reasoning_process": "thinking...", "id": 10},
+                {"chat_id": 3, "reasoning_process": "thinking hard...", "id": 30}
+            ],
+            "ai_response": [
+                {"chat_id": 1, "ai_response": "response 1", "id": 11},
+                {"chat_id": 2, "ai_response": "response 2", "id": 20},
+                {"chat_id": 3, "ai_response": "response 3", "id": 31}
+            ],
+            "user_input": [
+                {"chat_id": 1, "input_content": "hello", "input_location": "", "id": 1},
+                {"chat_id": 2, "input_content": "world", "input_location": "", "id": 2},
+                {"chat_id": 3, "input_content": "complex query", "input_location": "", "id": 3}
+            ]
+        }
+        self.short_term_memory = [1, 2, 3]
+
+    def test_logic_equivalence(self):
+        conn_optimized = MockMysqlConnect(self.mock_data)
+        res_optimized = add_short_term_memory_to_prompt(self.short_term_memory, conn_optimized, "model")
+
+        # Verify content
+        self.assertTrue(len(res_optimized) > 0)
+
+        # Verify calls count (should be 3)
+        self.assertEqual(conn_optimized.call_count, 3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/test/test_mysql_connect_in_clause.py
+++ b/server/test/test_mysql_connect_in_clause.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from utils.mysql_connect import MysqlConnect
+
+class TestMysqlConnectInClause(unittest.TestCase):
+    @patch('utils.mysql_connect.get_session_maker')
+    def test_in_clause(self, mock_get_session_maker):
+        # Setup mocks
+        mock_session = MagicMock()
+        mock_get_session_maker.return_value = MagicMock(return_value=mock_session)
+
+        db = MysqlConnect()
+
+        # Mock the model and column
+        mock_model_class = MagicMock()
+        mock_column = MagicMock()
+        setattr(mock_model_class, "some_field", mock_column)
+
+        # Test case 1: List with default key
+        conditions = {"some_field": [1, 2, 3]}
+        db._build_filter_conditions(mock_model_class, conditions)
+        mock_column.in_.assert_called_with([1, 2, 3])
+
+        # Test case 2: List with '=' suffix (e.g. 'some_field=')
+        # This currently fails without the fix.
+        conditions_equal = {"some_field=": [4, 5, 6]}
+        db._build_filter_conditions(mock_model_class, conditions_equal)
+        mock_column.in_.assert_called_with([4, 5, 6])
+
+        # Test case 3: List with tuple
+        conditions_tuple = {"some_field": (7, 8)}
+        db._build_filter_conditions(mock_model_class, conditions_tuple)
+        mock_column.in_.assert_called_with((7, 8))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/utils/mysql_connect.py
+++ b/server/utils/mysql_connect.py
@@ -82,29 +82,44 @@ class MysqlConnect:
         """
         filters = []
         for key, value in conditions.items():
-            if key.endswith("="):
-                field_name = key[:-1]
-                filters.append(getattr(model, field_name) == value)
-            elif key.endswith("<>"):
+            operator = "="
+            field_name = key
+
+            if key.endswith("<>"):
                 field_name = key[:-2]
-                filters.append(getattr(model, field_name) != value)
+                operator = "<>"
             elif key.endswith(">="):
                 field_name = key[:-2]
-                filters.append(getattr(model, field_name) >= value)
+                operator = ">="
             elif key.endswith("<="):
                 field_name = key[:-2]
-                filters.append(getattr(model, field_name) <= value)
+                operator = "<="
+            elif key.endswith("="):
+                field_name = key[:-1]
+                operator = "="
             elif key.endswith(">"):
                 field_name = key[:-1]
-                filters.append(getattr(model, field_name) > value)
+                operator = ">"
             elif key.endswith("<"):
                 field_name = key[:-1]
-                filters.append(getattr(model, field_name) < value)
-            elif isinstance(value, (list, tuple)):
-                filters.append(getattr(model, key).in_(value))
-            else:
-                # Default to equals
-                filters.append(getattr(model, key) == value)
+                operator = "<"
+
+            column = getattr(model, field_name)
+
+            if isinstance(value, (list, tuple)):
+                filters.append(column.in_(value))
+            elif operator == "=":
+                filters.append(column == value)
+            elif operator == "<>":
+                filters.append(column != value)
+            elif operator == ">=":
+                filters.append(column >= value)
+            elif operator == "<=":
+                filters.append(column <= value)
+            elif operator == ">":
+                filters.append(column > value)
+            elif operator == "<":
+                filters.append(column < value)
         return filters
 
     def create_record(self, table: str, data: dict):

--- a/server/utils/mysql_connect.py
+++ b/server/utils/mysql_connect.py
@@ -100,6 +100,8 @@ class MysqlConnect:
             elif key.endswith("<"):
                 field_name = key[:-1]
                 filters.append(getattr(model, field_name) < value)
+            elif isinstance(value, (list, tuple)):
+                filters.append(getattr(model, key).in_(value))
             else:
                 # Default to equals
                 filters.append(getattr(model, key) == value)


### PR DESCRIPTION
*   💡 **What:** Refactored `get_memory` in `server/handlers/memory_handlers.py` and `add_short_term_memory_to_prompt` in `server/services/prompt_generator.py` to use batched database queries. Updated `server/utils/mysql_connect.py` to support `IN` clause queries when passing lists as values.
*   🎯 **Why:** To eliminate N+1 query patterns where database calls were made inside loops for each chat message.
*   📊 **Impact:** Reduces database round-trips for retrieving chat history from `O(N)` to `O(1)` (specifically 3 queries instead of `3 * N`).
*   🔬 **Measurement:** Verified with a test script `server/test/test_memory_optimization.py` that query count drops significantly for batched inputs. Unit tested `MysqlConnect` modification with `server/test/test_mysql_connect_in_clause.py`.

---
*PR created automatically by Jules for task [15877067523326155165](https://jules.google.com/task/15877067523326155165) started by @noahpengding*