### PR TITLE
security: fix Datadog static analysis advisories

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,12 +15,14 @@ jobs:
   # Code quality check - runs on all branches
   ruff-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
         with:
           version: "latest"
 
@@ -44,12 +46,14 @@ jobs:
   # Web frontend lint check
   web-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
         with:
           bun-version: latest
 
@@ -80,10 +84,10 @@ jobs:
             path: './web'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@33119e582d3ab4ed79c2610af108cb08ff983917 # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -98,13 +102,13 @@ jobs:
 
       - name: Setup Python for Python analysis
         if: matrix.language == 'python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
       - name: Install uv for Python dependencies
         if: matrix.language == 'python'
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
         with:
           version: "latest"
 
@@ -117,7 +121,7 @@ jobs:
 
       - name: Setup Bun for JavaScript analysis
         if: matrix.language == 'javascript'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
         with:
           bun-version: latest
 
@@ -127,7 +131,7 @@ jobs:
         working-directory: ${{ matrix.path }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@33119e582d3ab4ed79c2610af108cb08ff983917 # v3
         with:
           category: "/language:${{ matrix.language }}"
           upload: true
@@ -142,20 +146,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push server test image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./server
           file: ./server/Dockerfile
@@ -175,20 +179,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push web test image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./web
           file: ./web/Dockerfile
@@ -209,20 +213,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push server x64 image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./server
           file: ./server/Dockerfile
@@ -244,20 +248,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push web x64 image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./web
           file: ./web/Dockerfile

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.12.0
     container_name: qdrant
     restart: always
     ports:
@@ -22,7 +22,7 @@ services:
       - /data/peng-agent/mysql:/var/lib/mysql
 
   peng-agent-redis:
-    image: redis:latest
+    image: redis:8.2.3
     container_name: peng-agent-redis
     restart: always
     ports:

--- a/test/docker-compose_with_app.yml
+++ b/test/docker-compose_with_app.yml
@@ -1,6 +1,6 @@
 services:
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.12.0
     container_name: qdrant
     restart: always
     ports:

--- a/test/docker-compose_with_ollama.yml
+++ b/test/docker-compose_with_ollama.yml
@@ -1,6 +1,6 @@
 services:
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.5.7
     container_name: ollama
     hostname: ollama
     restart: always
@@ -46,7 +46,7 @@ services:
     profiles: ["prod", "ollama"]
 
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.12.0
     container_name: qdrant
     restart: always
     networks:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,6 @@
 
 # Use the official Bun image as the base
-FROM oven/bun:latest AS builder
+FROM oven/bun:1.3.8 AS builder
 
 # Set the working directory
 WORKDIR /app
@@ -18,7 +18,7 @@ COPY . .
 RUN bun run build
 
 # Use a lightweight server for the final image
-FROM nginx:alpine
+FROM nginx:1.27.3-alpine
 
 # Install bash and envsubst
 RUN apk add --no-cache bash gettext


### PR DESCRIPTION
- Pin all GitHub Actions to commit SHAs for supply chain security
- Add explicit permissions to jobs missing GITHUB_TOKEN scoping
- Pin Docker base images to specific versions instead of 'latest':
  - qdrant/qdrant:latest -> v1.12.0
  - redis:latest -> 8.2.3
  - ollama/ollama:latest -> 0.5.7
  - oven/bun:latest -> 1.3.8
  - nginx:alpine -> 1.27.3-alpine

Addresses Datadog Code Security findings for:
- Workflow actions pinned by tag instead of hash
- No explicit permissions for GITHUB_TOKEN
- Use of 'latest' tag in Docker images

Note: 'Container may gain additional privileges' and 'writable filesystem' findings are expected for database services and have not been changed.

Fixes advised by: Tena Walcott