### PR TITLE
⚡ Bolt: Optimize MessageList re-renders

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - React.memo on MessageList
+**Learning:** In chat applications using streaming responses (token-by-token updates), lack of memoization on individual message components causes the entire list to re-render on every token. This is exponentially expensive with complex renderers like ReactMarkdown + SyntaxHighlighter.
+**Action:** Always memoize list items in append-only or streaming lists where only the last item changes frequently.

--- a/web/src/components/MessageItem.tsx
+++ b/web/src/components/MessageItem.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import 'katex/dist/katex.min.css';
+import { Message } from './ChatInterface.types';
+
+interface MessageItemProps {
+  message: Message;
+  index: number;
+  isFolded: boolean;
+  onToggleFold: (index: number, currentState: boolean) => void;
+  setRef: (el: HTMLDivElement | null, index: number) => void;
+}
+
+export const MessageItem = React.memo(({ message, index, isFolded, onToggleFold, setRef }: MessageItemProps) => {
+  const messageClass =
+    message.role === 'user'
+      ? 'user-message'
+      : message.type === 'tool_calls' || message.type === 'tool_output'
+        ? 'tool-message'
+        : message.type === 'reasoning_summary'
+          ? 'reasoning-message'
+          : 'assistant-message';
+
+  const isFoldable = message.type === 'tool_calls' || message.type === 'tool_output' || message.type === 'reasoning_summary';
+
+  return (
+    <div
+      className={`message ${messageClass} ${isFoldable && isFolded ? 'folded-clickable' : ''}`}
+      ref={(el) => setRef(el, index)}
+      onClick={() => {
+        if (isFoldable && isFolded) {
+          onToggleFold(index, isFolded);
+        }
+      }}
+    >
+      {/* For foldable messages (tool_calls, reasoning_summary), show a toggle */}
+      {isFoldable && (
+        <button
+          type="button"
+          className="tool-summary"
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleFold(index, isFolded);
+          }}
+        >
+          <span className="fold-arrow" aria-hidden="true">
+            {isFolded ? '⇨' : '⇩'}
+          </span>
+          <strong>
+            {message.type === 'tool_calls'
+              ? 'Tool Call'
+              : message.type === 'tool_output'
+                ? 'Tool Output'
+                : message.type === 'reasoning_summary'
+                  ? 'Reasoning Summary'
+                  : 'Message'}
+          </strong>
+        </button>
+      )}
+
+      {/* Show content unless folded */}
+      {!isFolded && (
+        <>
+          {message.images && message.images.length > 0 && (
+            <div className="message-images-container">
+              {message.images.map((imgSrc, imgIndex) => (
+                <div key={imgIndex} className="message-image-container">
+                  <img src={imgSrc} alt="Message attachment" className="message-image" />
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="message-text markdown-content">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm, remarkMath]}
+              rehypePlugins={[rehypeKatex]}
+              components={{
+                p: ({ ...props }) => <p className="tight-paragraph" {...props} />,
+                li: ({ ...props }) => <li className="tight-list-item" {...props} />,
+                code: (props: { inline?: boolean; className?: string; children?: React.ReactNode }) => {
+                  const { inline, className, children, ...rest } = props;
+                  const cls = className || '';
+                  const langToken = cls.split(' ').find((c) => c.startsWith('language-'));
+                  const lang = !inline && langToken ? langToken.replace('language-', '') : undefined;
+                  return !inline && lang ? (
+                    <SyntaxHighlighter style={vscDarkPlus as Record<string, React.CSSProperties>} language={lang} PreTag="div" {...rest}>
+                      {String(children).replace(/\n$/, '')}
+                    </SyntaxHighlighter>
+                  ) : (
+                    <code className={className} {...rest}>
+                      {children}
+                    </code>
+                  );
+                },
+              }}
+            >
+              {message.content}
+            </ReactMarkdown>
+          </div>
+        </>
+      )}
+    </div>
+  );
+});
+
+MessageItem.displayName = 'MessageItem';

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -1,12 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import remarkMath from 'remark-math';
-import rehypeKatex from 'rehype-katex';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import 'katex/dist/katex.min.css';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Message } from './ChatInterface.types';
+import { MessageItem } from './MessageItem';
 
 interface MessageListProps {
   messages: Message[];
@@ -17,19 +11,24 @@ export const MessageList: React.FC<MessageListProps> = ({ messages, isLoading })
   const [foldedMessages, setFoldedMessages] = useState<Record<string, boolean>>({});
   const messageRefs = useRef<Record<number, HTMLDivElement | null>>({});
 
-  const toggleFolded = (index: number, currentState: boolean) => {
+  const toggleFolded = useCallback((index: number, currentState: boolean) => {
     setFoldedMessages((prev) => ({
       ...prev,
       [index]: !currentState,
     }));
-  };
+  }, []);
+
+  const setRef = useCallback((el: HTMLDivElement | null, index: number) => {
+    messageRefs.current[index] = el;
+  }, []);
 
   // Auto-scroll logic for streaming long messages
   useEffect(() => {
     const lastMessageIndex = messages.length - 1;
     if (lastMessageIndex >= 0) {
       const lastMessage = messages[lastMessageIndex];
-      const isLongMessage = lastMessage.type === 'tool_calls' || lastMessage.type === 'tool_output' || lastMessage.type === 'reasoning_summary';
+      const isLongMessage =
+        lastMessage.type === 'tool_calls' || lastMessage.type === 'tool_output' || lastMessage.type === 'reasoning_summary';
 
       const isFolded = foldedMessages[lastMessageIndex] ?? lastMessage.folded ?? false;
 
@@ -54,97 +53,16 @@ export const MessageList: React.FC<MessageListProps> = ({ messages, isLoading })
     <div className="messages-list">
       {messages.map((message, index) => {
         const isFolded = foldedMessages[index] ?? message.folded ?? false;
-        const messageClass =
-          message.role === 'user'
-            ? 'user-message'
-            : message.type === 'tool_calls' || message.type === 'tool_output'
-              ? 'tool-message'
-              : message.type === 'reasoning_summary'
-                ? 'reasoning-message'
-                : 'assistant-message';
-
-        const isFoldable = message.type === 'tool_calls' || message.type === 'tool_output' || message.type === 'reasoning_summary';
 
         return (
-          <div
-            key={index}
-            className={`message ${messageClass} ${isFoldable && isFolded ? 'folded-clickable' : ''}`}
-            ref={(el) => {
-              messageRefs.current[index] = el;
-            }}
-            onClick={() => {
-              if (isFoldable && isFolded) {
-                toggleFolded(index, isFolded);
-              }
-            }}
-          >
-            {/* For foldable messages (tool_calls, reasoning_summary), show a toggle */}
-            {isFoldable && (
-              <button
-                type="button"
-                className="tool-summary"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  toggleFolded(index, isFolded);
-                }}
-              >
-                <span className="fold-arrow" aria-hidden="true">
-                  {isFolded ? '⇨' : '⇩'}
-                </span>
-                <strong>
-                  {message.type === 'tool_calls'
-                    ? 'Tool Call'
-                    : message.type === 'tool_output'
-                      ? 'Tool Output'
-                      : message.type === 'reasoning_summary'
-                        ? 'Reasoning Summary'
-                        : 'Message'}
-                </strong>
-              </button>
-            )}
-
-            {/* Show content unless folded */}
-            {!isFolded && (
-              <>
-                {message.images && message.images.length > 0 && (
-                  <div className="message-images-container">
-                    {message.images.map((imgSrc, imgIndex) => (
-                      <div key={imgIndex} className="message-image-container">
-                        <img src={imgSrc} alt="Message attachment" className="message-image" />
-                      </div>
-                    ))}
-                  </div>
-                )}
-                <div className="message-text markdown-content">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm, remarkMath]}
-                    rehypePlugins={[rehypeKatex]}
-                    components={{
-                      p: ({ ...props }) => <p className="tight-paragraph" {...props} />,
-                      li: ({ ...props }) => <li className="tight-list-item" {...props} />,
-                      code: (props: { inline?: boolean; className?: string; children?: React.ReactNode }) => {
-                        const { inline, className, children, ...rest } = props;
-                        const cls = className || '';
-                        const langToken = cls.split(' ').find((c) => c.startsWith('language-'));
-                        const lang = !inline && langToken ? langToken.replace('language-', '') : undefined;
-                        return !inline && lang ? (
-                          <SyntaxHighlighter style={vscDarkPlus as Record<string, React.CSSProperties>} language={lang} PreTag="div" {...rest}>
-                            {String(children).replace(/\n$/, '')}
-                          </SyntaxHighlighter>
-                        ) : (
-                          <code className={className} {...rest}>
-                            {children}
-                          </code>
-                        );
-                      },
-                    }}
-                  >
-                    {message.content}
-                  </ReactMarkdown>
-                </div>
-              </>
-            )}
-          </div>
+          <MessageItem
+            key={message.messageId || index}
+            message={message}
+            index={index}
+            isFolded={isFolded}
+            onToggleFold={toggleFolded}
+            setRef={setRef}
+          />
         );
       })}
       {isLoading && (


### PR DESCRIPTION
💡 What: Extracted `MessageItem` from `MessageList.tsx` and wrapped it in `React.memo`. Implemented stable callbacks for `onToggleFold` and `setRef`.
🎯 Why: To prevent the entire message list (and expensive Markdown/SyntaxHighlighter components) from re-rendering on every single token update during streaming responses.
📊 Impact: Reduces re-renders from O(N) per token to O(1) per token for the list.
🔬 Measurement: Verified with `bun run build` and `bun run lint`. Visual verification of app startup successful.


---
*PR created automatically by Jules for task [4021225422637757525](https://jules.google.com/task/4021225422637757525) started by @noahpengding*