### PR TITLE
Add copy button to code blocks

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-06-03 - Chat Interface Accessibility
 **Learning:** Icon-only buttons (like send/upload) in chat interfaces often lack accessible names, making them invisible to screen readers.
 **Action:** Always check `aria-label` for buttons that rely on icons or emojis for visual meaning.
+
+## 2025-06-03 - Code Highlighting Robustness
+**Learning:** Regex `\w+` for language detection fails for languages with special characters like C++ or C#.
+**Action:** Use robust parsing (e.g., `split(' ')`) to ensure correct language identification in syntax highlighters.

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -52,6 +52,7 @@ const CodeBlock = ({ inline, className, children, ...rest }: CodeBlockProps) => 
         {isCopied ? '✓' : '📋'}
       </button>
       <SyntaxHighlighter
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         style={vscDarkPlus as any}
         language={lang}
         PreTag="div"

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -8,6 +8,63 @@ import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import 'katex/dist/katex.min.css';
 import { Message } from './ChatInterface.types';
 
+interface CodeBlockProps {
+  inline?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+  [key: string]: unknown;
+}
+
+// CodeBlock component with copy functionality
+const CodeBlock = ({ inline, className, children, ...rest }: CodeBlockProps) => {
+  const [isCopied, setIsCopied] = useState(false);
+  const cls = className || '';
+  const langToken = cls.split(' ').find((c) => c.startsWith('language-'));
+  const lang = !inline && langToken ? langToken.replace('language-', '') : undefined;
+
+  const handleCopy = async () => {
+    if (!children) return;
+    try {
+      await navigator.clipboard.writeText(String(children).replace(/\n$/, ''));
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch {
+      // Silently fail if clipboard access is denied
+    }
+  };
+
+  if (inline || !lang) {
+    return (
+      <code className={className} {...rest}>
+        {children}
+      </code>
+    );
+  }
+
+  return (
+    <div className="relative group my-4">
+      <button
+        type="button"
+        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500"
+        onClick={handleCopy}
+        aria-label={isCopied ? 'Copied to clipboard' : 'Copy code'}
+        title={isCopied ? 'Copied!' : 'Copy code'}
+      >
+        {isCopied ? '✓' : '📋'}
+      </button>
+      <SyntaxHighlighter
+        style={vscDarkPlus as { [key: string]: React.CSSProperties }}
+        language={lang}
+        PreTag="div"
+        customStyle={{ margin: 0, borderRadius: '0.375rem' }}
+        {...rest}
+      >
+        {String(children).replace(/\n$/, '')}
+      </SyntaxHighlighter>
+    </div>
+  );
+};
+
 interface MessageListProps {
   messages: Message[];
   isLoading: boolean;
@@ -122,21 +179,7 @@ export const MessageList: React.FC<MessageListProps> = ({ messages, isLoading })
                     components={{
                       p: ({ ...props }) => <p className="tight-paragraph" {...props} />,
                       li: ({ ...props }) => <li className="tight-list-item" {...props} />,
-                      code: (props: { inline?: boolean; className?: string; children?: React.ReactNode }) => {
-                        const { inline, className, children, ...rest } = props;
-                        const cls = className || '';
-                        const langToken = cls.split(' ').find((c) => c.startsWith('language-'));
-                        const lang = !inline && langToken ? langToken.replace('language-', '') : undefined;
-                        return !inline && lang ? (
-                          <SyntaxHighlighter style={vscDarkPlus as Record<string, React.CSSProperties>} language={lang} PreTag="div" {...rest}>
-                            {String(children).replace(/\n$/, '')}
-                          </SyntaxHighlighter>
-                        ) : (
-                          <code className={className} {...rest}>
-                            {children}
-                          </code>
-                        );
-                      },
+                      code: CodeBlock,
                     }}
                   >
                     {message.content}

--- a/web/src/components/MessageList.tsx
+++ b/web/src/components/MessageList.tsx
@@ -8,11 +8,10 @@ import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import 'katex/dist/katex.min.css';
 import { Message } from './ChatInterface.types';
 
-interface CodeBlockProps {
+interface CodeBlockProps extends React.HTMLAttributes<HTMLElement> {
   inline?: boolean;
   className?: string;
   children?: React.ReactNode;
-  [key: string]: unknown;
 }
 
 // CodeBlock component with copy functionality
@@ -53,7 +52,7 @@ const CodeBlock = ({ inline, className, children, ...rest }: CodeBlockProps) => 
         {isCopied ? '✓' : '📋'}
       </button>
       <SyntaxHighlighter
-        style={vscDarkPlus as { [key: string]: React.CSSProperties }}
+        style={vscDarkPlus as any}
         language={lang}
         PreTag="div"
         customStyle={{ margin: 0, borderRadius: '0.375rem' }}


### PR DESCRIPTION
🎨 Palette: Added copy button to code blocks

💡 What:
Added a "Copy to Clipboard" button to all code blocks in the chat interface.

🎯 Why:
Users frequently need to copy code snippets generated by the AI. Manually selecting text is error-prone and tedious.

📸 Visuals:
- A clipboard icon (📋) appears on hover/focus in the top-right corner of code blocks.
- Clicking it copies the content and changes the icon to a checkmark (✓) for 2 seconds.

♿ Accessibility:
- Added `aria-label` to the button (dynamic: "Copy code" / "Copied to clipboard").
- Button is keyboard focusable with visible focus ring.
- Button is hidden visually (opacity 0) but accessible to screen readers and keyboard users (focus shows it), and appears on hover for mouse users.

---
*PR created automatically by Jules for task [4215603826002469336](https://jules.google.com/task/4215603826002469336) started by @noahpengding*