### PR TITLE
🎨 Palette: Change 'Back to Home' div to semantic button

### DIFF
--- a/web/src/components/ModelInterface.css
+++ b/web/src/components/ModelInterface.css
@@ -41,6 +41,7 @@
   padding: 0.75rem;
   background-color: #212121;
   color: white;
+  border: none;
   border-radius: 0.25rem;
   text-align: center;
   font-weight: 500;

--- a/web/src/components/ModelInterface.tsx
+++ b/web/src/components/ModelInterface.tsx
@@ -185,9 +185,9 @@ const ModelInterface: React.FC = () => {
       <div className="main-content">
         {/* Sidebar with filters */}
         <div className="sidebar">
-          <div className="home-button" onClick={() => navigate('/')} role="button">
+          <button className="home-button" onClick={() => navigate('/')}>
             Back to Home
-          </div>
+          </button>
 
           <div className="sidebar-title">Filters</div>
 


### PR DESCRIPTION
💡 **What**: Changed the "Back to Home" navigation element in `ModelInterface.tsx` from a `<div>` to a `<button>`. Updated `.home-button` in `ModelInterface.css` with `border: none;` to maintain the existing visual appearance.

🎯 **Why**: Using a `<button>` element is better for accessibility because it provides native keyboard support (focusing via `Tab` and activation via `Enter`/`Space`) and semantic meaning out-of-the-box, without requiring additional implementation.

♿ **Accessibility**: Provides native keyboard support and semantic HTML.

---
*PR created automatically by Jules for task [3240889720679753054](https://jules.google.com/task/3240889720679753054) started by @noahpengding*