### PR TITLE
🎨 Palette: Improve error message accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,4 @@
 ## 2025-06-03 - Code Highlighting Robustness
 **Learning:** Regex `\w+` for language detection fails for languages with special characters like C++ or C#.
 **Action:** Use robust parsing (e.g., `split(' ')`) to ensure correct language identification in syntax highlighters.
+## 2026-03-21 - Error Message Accessibility\n**Learning:** Error messages that appear dynamically (like after a failed login or failed API call) are often missed by screen readers unless they are focused or have an ARIA alert role.\n**Action:** Always add `role="alert"` and `aria-live="assertive"` to error message containers so they are immediately announced when they appear in the DOM.

--- a/app/web/src/components/ChatInterface.tsx
+++ b/app/web/src/components/ChatInterface.tsx
@@ -394,6 +394,8 @@ const ChatbotUI = () => {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}
             className="error-message"
+            role="alert"
+            aria-live="assertive"
           >
             {displayError}
           </motion.div>

--- a/app/web/src/components/Login.tsx
+++ b/app/web/src/components/Login.tsx
@@ -156,6 +156,8 @@ const Login: React.FC = () => {
                   exit={{ opacity: 0, scale: 0.95 }}
                   transition={{ type: 'spring', stiffness: 500, damping: 30 }}
                   className="login-error"
+                  role="alert"
+                  aria-live="assertive"
                 >
                   <svg className="login-error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                     <circle cx="12" cy="12" r="10" />

--- a/app/web/src/components/UserProfilePopup.tsx
+++ b/app/web/src/components/UserProfilePopup.tsx
@@ -153,7 +153,7 @@ const UserProfilePopup: React.FC<UserProfilePopupProps> = ({ isOpen, onClose, av
               {loading ? (
                 <div className="loading-indicator">Loading profile...</div>
               ) : error ? (
-                <div className="error-message">{error}</div>
+                <div className="error-message" role="alert" aria-live="assertive">{error}</div>
               ) : profile ? (
                 <div className="profile-form">
                   <div className="form-group">


### PR DESCRIPTION
## 🎨 Palette: Improve error message accessibility

**💡 What:** Added `role="alert"` and `aria-live="assertive"` to the `.login-error` and `.error-message` containers in `Login.tsx`, `ChatInterface.tsx`, and `UserProfilePopup.tsx`.
**🎯 Why:** Error messages that appear dynamically after user action (like a failed login attempt or API error) are often missed by screen readers if they lack an explicit ARIA role.
**♿ Accessibility:** Screen readers will now immediately interrupt and announce these critical error messages as soon as they appear in the DOM, greatly improving the usability for visually impaired users.

---
*PR created automatically by Jules for task [11137849341174920960](https://jules.google.com/task/11137849341174920960) started by @noahpengding*