### PR TITLE
⚡ Bolt: Add React.memo to CodeBlock to prevent unnecessary re-renders during streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,4 +5,6 @@ Since Redux Toolkit uses Immer under the hood, we can directly mutate `state.mes
 Since the array is just mutated, Immer will handle the structural sharing optimally, reducing garbage collection pressure and main thread blocking during fast streaming.
 We can use a simple backward loop `for (let i = state.messages.length - 1; i >= 0; i--)` to find the messages matching `messageId` and modify them directly, breaking early if we know we've processed all messages for this turn. (Or since we just want to update all for `messageId`, a backward loop is fast enough).
 
-**Action:** Replace `state.messages = state.messages.map(...)` with a backwards iteration that mutates the elements directly in `handleChunk`, `finishMessage`, `attachChatIdToMessage` and `submitMessageFeedback` extraReducers.
+**Action:** Replace `state.messages = state.messages.map(...)` with a backwards iteration that mutates the elements directly in `handleChunk`, `finishMessage`, `attachChatIdToMessage` and `submitMessageFeedback` extraReducers.## 2026-03-27 - [Frontend Streaming Optimization]
+**Learning:** ReactMarkdown generates new elements on every chunk during AI streaming, causing expensive components like `SyntaxHighlighter` inside `CodeBlock` to parse and render repeatedly. This leads to severe lag and UI jank when generating code blocks.
+**Action:** Wrap the `CodeBlock` component with `React.memo` and provide a custom equality function that ignores `react-markdown`'s internal AST `node` mutations, checking only if the stringified `children`, `inline`, and `className` props change.

--- a/app/web/src/components/MessageItem.tsx
+++ b/app/web/src/components/MessageItem.tsx
@@ -67,6 +67,16 @@ const CodeBlock = ({ inline, className, children, ...rest }: CodeBlockProps) => 
   );
 };
 
+// ⚡ Bolt Optimization: Memoize the CodeBlock component to prevent it from re-rendering
+// during streaming if its contents haven't changed. ReactMarkdown generates new elements
+// on every chunk, causing SyntaxHighlighter (which is very expensive) to parse and render
+// repeatedly. We only re-render if the stringified children, inline, or className change.
+const MemoizedCodeBlock = React.memo(CodeBlock, (prev, next) => {
+  const prevChildrenString = Array.isArray(prev.children) ? prev.children.join('') : String(prev.children);
+  const nextChildrenString = Array.isArray(next.children) ? next.children.join('') : String(next.children);
+  return prev.className === next.className && prev.inline === next.inline && prevChildrenString === nextChildrenString;
+});
+
 interface MessageItemProps {
   message: Message;
   index: number;
@@ -167,7 +177,7 @@ export const MessageItem = React.memo(({ message, index, isFolded, onToggleFold,
               components={{
                 p: ({ ...props }) => <p className="tight-paragraph" {...props} />,
                 li: ({ ...props }) => <li className="tight-list-item" {...props} />,
-                code: CodeBlock,
+                code: MemoizedCodeBlock,
               }}
             >
               {message.content}


### PR DESCRIPTION
💡 **What**: Wrapped the `CodeBlock` component in `React.memo` with a custom equality function inside `MessageItem.tsx`.
🎯 **Why**: During AI streaming, `react-markdown` generates new elements for every chunk. This caused the `SyntaxHighlighter` component—which is very computationally expensive—to parse and render repeatedly, leading to significant UI lag and jank when long code blocks were being generated.
📊 **Impact**: Reduces CPU usage and UI blocking substantially during streaming of code responses. `SyntaxHighlighter` now only re-renders when the actual code string, language class, or inline status changes, rather than on every single token.
🔬 **Measurement**: Verified the frontend runs smoothly by visually inspecting the generation of a Python code block and checking for unnecessary re-renders using React DevTools during a streaming response.

---
*PR created automatically by Jules for task [14506303924661134937](https://jules.google.com/task/14506303924661134937) started by @noahpengding*