### PR TITLE
⚡ Bolt: Optimize CodeBlock rendering performance during streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,9 @@ Since the array is just mutated, Immer will handle the structural sharing optima
 We can use a simple backward loop `for (let i = state.messages.length - 1; i >= 0; i--)` to find the messages matching `messageId` and modify them directly, breaking early if we know we've processed all messages for this turn. (Or since we just want to update all for `messageId`, a backward loop is fast enough).
 
 **Action:** Replace `state.messages = state.messages.map(...)` with a backwards iteration that mutates the elements directly in `handleChunk`, `finishMessage`, `attachChatIdToMessage` and `submitMessageFeedback` extraReducers.
+
+## 2024-05-20 - BOLT - Frontend Performance Optimization
+**Learning:** When using `react-markdown` to render streaming responses, `react-syntax-highlighter` inside a custom `CodeBlock` component can cause severe UI lag. The library is heavy, and by default, React re-renders all code blocks in the message whenever a new chunk arrives, even if their content hasn't changed.
+We can avoid this by memoizing the custom `CodeBlock` component using `React.memo` with a custom equality check that compares `className`, `inline`, and the stringified `children`. This prevents re-rendering older, unmodified code blocks when new text is appended elsewhere in the stream.
+
+**Action:** Wrap expensive markdown components (like `CodeBlock`) in `React.memo` with a custom equality check (`prevProps.className === nextProps.className && prevProps.inline === nextProps.inline && String(prevProps.children) === String(nextProps.children)`) when dealing with streaming chunk updates.

--- a/app/web/src/components/MessageItem.tsx
+++ b/app/web/src/components/MessageItem.tsx
@@ -15,7 +15,7 @@ interface CodeBlockProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 // CodeBlock component with copy functionality
-const CodeBlock = ({ inline, className, children, ...rest }: CodeBlockProps) => {
+const CodeBlock = React.memo(({ inline, className, children, ...rest }: CodeBlockProps) => {
   const [isCopied, setIsCopied] = useState(false);
   const cls = className || '';
   const langToken = cls.split(' ').find((c) => c.startsWith('language-'));
@@ -65,7 +65,12 @@ const CodeBlock = ({ inline, className, children, ...rest }: CodeBlockProps) => 
       </SyntaxHighlighter>
     </div>
   );
-};
+}, (prevProps, nextProps) => {
+  return prevProps.className === nextProps.className &&
+    prevProps.inline === nextProps.inline &&
+    String(prevProps.children) === String(nextProps.children);
+});
+CodeBlock.displayName = 'CodeBlock';
 
 interface MessageItemProps {
   message: Message;


### PR DESCRIPTION
💡 **What:** Wrapped the custom `CodeBlock` component inside `MessageItem.tsx` with `React.memo` and implemented a custom equality function that compares `className`, `inline`, and stringified `children`.

🎯 **Why:** When `react-markdown` receives streaming chunks, it rebuilds the AST and triggers a re-render of all its children. The `react-syntax-highlighter` component inside `CodeBlock` is very heavy to render. By default, it would re-render for every single chunk, even if the code block content hasn't changed, causing severe UI lag (blocking the main thread) during fast streaming.

📊 **Impact:** Reduces main-thread blocking significantly during streaming when there are code blocks in the message. Turns $O(N \cdot M)$ re-rendering into $O(1)$ for unmodified codeblocks (where $N$ is chunk count and $M$ is codeblock count).

🔬 **Measurement:** Verify by rendering a message with multiple large code blocks while new text is streaming below them. Use React Profiler or Chrome DevTools Performance tab to observe that the existing `CodeBlock` components do not re-render as new chunks arrive.

---
*PR created automatically by Jules for task [8724741984835437110](https://jules.google.com/task/8724741984835437110) started by @noahpengding*