### PR TITLE
🎨 Palette: Add loading spinner and dynamic ARIA label to chat send button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,4 +5,11 @@
 ## 2025-06-03 - Code Highlighting Robustness
 **Learning:** Regex `\w+` for language detection fails for languages with special characters like C++ or C#.
 **Action:** Use robust parsing (e.g., `split(' ')`) to ensure correct language identification in syntax highlighters.
-## 2026-03-21 - Error Message Accessibility\n**Learning:** Error messages that appear dynamically (like after a failed login or failed API call) are often missed by screen readers unless they are focused or have an ARIA alert role.\n**Action:** Always add `role="alert"` and `aria-live="assertive"` to error message containers so they are immediately announced when they appear in the DOM.
+
+## 2026-03-21 - Error Message Accessibility
+**Learning:** Error messages that appear dynamically (like after a failed login or failed API call) are often missed by screen readers unless they are focused or have an ARIA alert role.
+**Action:** Always add `role="alert"` and `aria-live="assertive"` to error message containers so they are immediately announced when they appear in the DOM.
+
+## 2025-02-23 - Async Action Accessibility
+**Learning:** Form submit buttons without explicit loading state fail to communicate that background processing is happening, especially problematic for screen readers.
+**Action:** Always provide a clear loading state (e.g. SVG spinner) and update the `aria-label` (e.g. "Sending message...") to ensure feedback for interactive processes.

--- a/app/web/src/components/InputArea.tsx
+++ b/app/web/src/components/InputArea.tsx
@@ -228,10 +228,22 @@ export const InputArea: React.FC<InputAreaProps> = ({
             <button
               type="submit"
               className="send-button"
-              aria-label="Send message"
+              aria-label={isLoading ? 'Sending message...' : 'Send message'}
               disabled={isLoading || isUploading || (!input.trim() && uploadedImages.length === 0 && s3PathsInput.trim().length === 0)}
             >
-              ➤
+              {isLoading ? (
+                <svg
+                  className="send-spinner"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  style={{ animation: 'spin 1s linear infinite', width: '20px', height: '20px' }}
+                >
+                  <circle cx="12" cy="12" r="10" stroke="rgba(255,255,255,0.25)" strokeWidth="3" />
+                  <path d="M12 2a10 10 0 0 1 10 10" stroke="white" strokeWidth="3" strokeLinecap="round" />
+                </svg>
+              ) : (
+                '➤'
+              )}
             </button>
           </div>
         </div>


### PR DESCRIPTION
💡 **What**: Added an SVG loading spinner and dynamic `aria-label` to the send button in the `<InputArea>` component.
🎯 **Why**: When a user submits a message, the button simply disabled without any visual or screen-reader indication of a loading state. The new visual feedback confirms their request is being processed.
📸 **Before/After**: The button changed from an unresponsive "➤" to a spinning loading icon, matching the application's overall visual language (reusing the spin animation from Login.css).
♿ **Accessibility**: Dynamically changes the `aria-label` from "Send message" to "Sending message..." during loading, keeping screen-reader users informed of the async operation in progress.

---
*PR created automatically by Jules for task [11688322369151362309](https://jules.google.com/task/11688322369151362309) started by @noahpengding*