### PR TITLE
🎨 Palette: [Fix keyboard accessibility for password toggle in Login]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 **Learning:** Regex `\w+` for language detection fails for languages with special characters like C++ or C#.
 **Action:** Use robust parsing (e.g., `split(' ')`) to ensure correct language identification in syntax highlighters.
 ## 2026-03-21 - Error Message Accessibility\n**Learning:** Error messages that appear dynamically (like after a failed login or failed API call) are often missed by screen readers unless they are focused or have an ARIA alert role.\n**Action:** Always add `role="alert"` and `aria-live="assertive"` to error message containers so they are immediately announced when they appear in the DOM.
+
+## 2023-10-27 - Keyboard Accessibility for Interactive Elements
+**Learning:** Adding `tabIndex={-1}` to interactive elements like buttons (e.g., a "Show/Hide password" toggle) removes them from the document's tab order, making them inaccessible to keyboard-only and screen reader users.
+**Action:** Ensure that native interactive elements (`<button>`, `<a>`, `<input>`) do not have `tabIndex={-1}` unless explicitly intended to be skipped and focus is managed programmatically elsewhere.

--- a/app/web/src/components/Login.tsx
+++ b/app/web/src/components/Login.tsx
@@ -110,7 +110,6 @@ const Login: React.FC = () => {
                   type="button"
                   className="login-eye-btn"
                   onClick={() => setShowPassword((v) => !v)}
-                  tabIndex={-1}
                   aria-label={showPassword ? 'Hide password' : 'Show password'}
                 >
                   <EyeIcon open={showPassword} />


### PR DESCRIPTION
💡 **What:** Removed `tabIndex={-1}` from the password visibility toggle button in the Login component.
🎯 **Why:** To ensure keyboard-only and screen reader users can navigate to and activate the button, improving overall accessibility.
♿ **Accessibility:** The password toggle button is now naturally included in the document's tab order, allowing users to focus it using the 'Tab' key and toggle it via keyboard interactions.

---
*PR created automatically by Jules for task [5835467777846963475](https://jules.google.com/task/5835467777846963475) started by @noahpengding*