### PR TITLE
🎨 Palette: Fix keyboard accessibility for password visibility toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 **Learning:** Regex `\w+` for language detection fails for languages with special characters like C++ or C#.
 **Action:** Use robust parsing (e.g., `split(' ')`) to ensure correct language identification in syntax highlighters.
 ## 2026-03-21 - Error Message Accessibility\n**Learning:** Error messages that appear dynamically (like after a failed login or failed API call) are often missed by screen readers unless they are focused or have an ARIA alert role.\n**Action:** Always add `role="alert"` and `aria-live="assertive"` to error message containers so they are immediately announced when they appear in the DOM.
+
+## 2023-10-27 - Keyboard Navigation & tabindex
+**Learning:** Adding `tabIndex={-1}` to interactive elements (like an icon button used to toggle password visibility) completely breaks keyboard accessibility by removing the element from the tab order.
+**Action:** Never use `tabIndex={-1}` on elements that users need to click or interact with. Rely on default tab ordering for standard semantic interactive elements (`<button>`, `<a>`, `<input>`, etc.).

--- a/app/web/src/components/Login.tsx
+++ b/app/web/src/components/Login.tsx
@@ -110,7 +110,6 @@ const Login: React.FC = () => {
                   type="button"
                   className="login-eye-btn"
                   onClick={() => setShowPassword((v) => !v)}
-                  tabIndex={-1}
                   aria-label={showPassword ? 'Hide password' : 'Show password'}
                 >
                   <EyeIcon open={showPassword} />


### PR DESCRIPTION
💡 **What:** Removed `tabIndex={-1}` from the "Show password" toggle button in the Login component.
🎯 **Why:** The `tabIndex={-1}` attribute actively removed the button from the document's sequential tab order. This prevented users who navigate via keyboard from being able to focus on and use the button to toggle password visibility, a key accessibility failure.
📸 **Before/After:** No visual changes. Keyboard tab ordering now correctly includes the eye icon button after the password input field.
♿ **Accessibility:** Fixes a keyboard navigation barrier. Users can now tab to the "Show password" button and toggle it using the Enter or Space keys.

---
*PR created automatically by Jules for task [6973321210841060004](https://jules.google.com/task/6973321210841060004) started by @noahpengding*