### PR TITLE
🎨 Palette: [UX improvement] removed tabIndex={-1} to ensure keyboard accessibility

### DIFF
--- a/app/web/src/components/Login.tsx
+++ b/app/web/src/components/Login.tsx
@@ -110,7 +110,6 @@ const Login: React.FC = () => {
                   type="button"
                   className="login-eye-btn"
                   onClick={() => setShowPassword((v) => !v)}
-                  tabIndex={-1}
                   aria-label={showPassword ? 'Hide password' : 'Show password'}
                 >
                   <EyeIcon open={showPassword} />


### PR DESCRIPTION
💡 What: Removed `tabIndex={-1}` from the password visibility toggle button on the login screen.
🎯 Why: It prevented the button from being focused using the keyboard, which made toggling password visibility inaccessible to keyboard users and screen readers.
📸 Before/After: Before, keyboard-only users could not reach the toggle button via 'Tab'. After, the button receives focus normally and works as expected.
♿ Accessibility: Ensures that keyboard users and screen readers can interact with the password visibility toggle.

---
*PR created automatically by Jules for task [11409130156769204332](https://jules.google.com/task/11409130156769204332) started by @noahpengding*