### PR TITLE
🎨 Palette: [UX improvement] Enhance disabled button feedback and menu accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-02-23 - Async Action Accessibility
 **Learning:** Form submit buttons without explicit loading state fail to communicate that background processing is happening, especially problematic for screen readers.
 **Action:** Always provide a clear loading state (e.g. SVG spinner) and update the `aria-label` (e.g. "Sending message...") to ensure feedback for interactive processes.
+
+## 2026-05-09 - Disabled State Tooltips and Menu Accessibility
+**Learning:** Disabled buttons without clear tooltips confuse users. Dynamic `title` attributes based on the exact reason for the disabled state provide much better UX. Also, custom menus require `aria-expanded`, `aria-haspopup`, and `role="menuitem"` to be fully accessible to screen readers.
+**Action:** Always provide dynamic `title` and `aria-label` for buttons that can be disabled for multiple reasons. Always use correct ARIA roles and states for custom dropdown menus.

--- a/app/web/src/components/ChatInterface.tsx
+++ b/app/web/src/components/ChatInterface.tsx
@@ -328,7 +328,9 @@ const ChatbotUI = () => {
         <button
           type="button"
           className="menu-button"
-          aria-label="Open menu"
+          aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={isMenuOpen}
+          aria-haspopup="menu"
           title="Menu"
           onClick={() => setIsMenuOpen((v) => !v)}
         >
@@ -340,18 +342,19 @@ const ChatbotUI = () => {
             role="menu"
             aria-label="Navigation Menu"
           >
-            <a href="/memory" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/memory" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               Memory
             </a>
-            <a href="/model" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/model" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               Model
             </a>
-            <a href="/rag" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/rag" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               RAG
             </a>
             <a
               href="https://us5.datadoghq.com/llm/applications?query=&fromUser=true&start=1770794053588&end=1770880453588&paused=false"
               className="menu-item external-link"
+              role="menuitem"
               target="_blank"
               rel="noreferrer"
               onClick={() => setIsMenuOpen(false)}
@@ -361,6 +364,7 @@ const ChatbotUI = () => {
             <a
               href="https://github.com/Noahdingpeng/peng-agent"
               className="menu-item external-link"
+              role="menuitem"
               target="_blank"
               rel="noreferrer"
               onClick={() => setIsMenuOpen(false)}

--- a/app/web/src/components/InputArea.tsx
+++ b/app/web/src/components/InputArea.tsx
@@ -219,8 +219,8 @@ export const InputArea: React.FC<InputAreaProps> = ({
               type="button"
               onClick={() => fileInputRef.current?.click()}
               className="upload-button"
-              title="Upload image or PDF"
-              aria-label="Upload image or PDF"
+              title={isUploading ? 'Uploading...' : isLoading ? 'Please wait...' : 'Upload image or PDF'}
+              aria-label={isUploading ? 'Uploading...' : isLoading ? 'Please wait...' : 'Upload image or PDF'}
               disabled={isLoading || isUploading}
             >
               {isUploading ? '⏳' : '📎'}
@@ -228,7 +228,8 @@ export const InputArea: React.FC<InputAreaProps> = ({
             <button
               type="submit"
               className="send-button"
-              aria-label={isLoading ? 'Sending message...' : 'Send message'}
+              title={isLoading ? 'Sending message...' : isUploading ? 'Please wait for upload to finish' : (!input.trim() && uploadedImages.length === 0 && s3PathsInput.trim().length === 0) ? 'Type a message to send' : 'Send message'}
+              aria-label={isLoading ? 'Sending message...' : isUploading ? 'Please wait for upload to finish' : (!input.trim() && uploadedImages.length === 0 && s3PathsInput.trim().length === 0) ? 'Type a message to send' : 'Send message'}
               disabled={isLoading || isUploading || (!input.trim() && uploadedImages.length === 0 && s3PathsInput.trim().length === 0)}
             >
               {isLoading ? (


### PR DESCRIPTION
### 💡 What
This PR adds specific, dynamic tooltips and accessible labels to disabled buttons in the chat input area, and improves the accessibility structure of the custom dropdown menu in the chat interface.

### 🎯 Why
- **Disabled buttons without context are confusing:** When a user can't click "Send" or "Upload", they often don't know why. By adding dynamic tooltips (e.g., "Please wait for upload to finish" or "Type a message to send"), we give immediate, helpful feedback.
- **Custom menus are invisible to screen readers without ARIA:** The options menu lacked proper ARIA states and roles, making it difficult for keyboard and screen reader users to navigate.

### 📸 Before/After
*(Visuals remain identical except for native browser tooltips on hover. See attached verification screenshots.)*

### ♿ Accessibility
- Added dynamic `aria-label` and `title` to `upload-button` and `send-button` matching their specific disabled reasons.
- Added `aria-expanded={isMenuOpen}` and `aria-haspopup="menu"` to the main `menu-button`.
- Updated the `menu-button`'s `aria-label` to toggle between "Open menu" and "Close menu".
- Added `role="menuitem"` to all anchor tags within the `.menu-dropdown`.

---
*PR created automatically by Jules for task [8489953453632774873](https://jules.google.com/task/8489953453632774873) started by @noahpengding*