### PR TITLE
⚡ Bolt: [performance improvement] Memoize Mobile Markdown Rendering

### DIFF
--- a/app/mobile/src/screens/ChatScreen.tsx
+++ b/app/mobile/src/screens/ChatScreen.tsx
@@ -50,6 +50,12 @@ const md = new MarkdownIt({
   typographer: true,
 }).use(markdownItKatex);
 
+const MemoizedMarkdown = React.memo(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (props: any) => <Markdown {...props} />,
+  (prev, next) => prev.children === next.children && prev.style === next.style
+);
+
 const markdownRules: RenderRules = {
   math_inline: (
     node: ASTNode,
@@ -137,13 +143,13 @@ const MessageItem = React.memo(({
             )}
             {!isFolded && (
               <View>
-                <Markdown 
+                <MemoizedMarkdown
                   style={markdownStyles}
                   markdownit={md}
                   rules={markdownRules}
                 >
                   {item.content}
-                </Markdown>
+                </MemoizedMarkdown>
                 {item.chatId && item.messageId && item.type === 'output_text' && (
                   <View style={styles.feedbackContainer}>
                     <TouchableOpacity
@@ -175,13 +181,13 @@ const MessageItem = React.memo(({
             )}
           </>
         ) : (
-          <Markdown 
+          <MemoizedMarkdown
             style={userMarkdownStyles}
             markdownit={md}
             rules={markdownRules}
           >
             {item.content}
-          </Markdown>
+          </MemoizedMarkdown>
         )}
       </View>
     </View>


### PR DESCRIPTION
### 💡 What
Wrapped the `<Markdown>` component from `react-native-markdown-display` with `React.memo` inside `app/mobile/src/screens/ChatScreen.tsx`. A custom equality check was added to only re-render if the `children` (markdown content) or `style` props have changed.

### 🎯 Why
During AI response streaming, the `MessageItem` component frequently updates. The original `<Markdown>` component was not memoized, causing the expensive markdown-it parsing and AST node generation to re-run for all previous chunks and even when unrelated state (like the feedback status) updated. This led to significant UI lag and jank on mobile devices.

### 📊 Impact
Reduces unnecessary re-renders of the markdown component by nearly 100% for static messages and significantly limits the parsing overhead strictly to the actively streaming message. This results in much smoother scrolling and UI responsiveness during generation.

### 🔬 Measurement
1. Run the mobile application.
2. Initiate a long, streamed AI response.
3. Observe that the UI no longer stutters when the message updates or when feedback icons are tapped.
4. Profiling in React Native Debugger will show `MemoizedMarkdown` bailing out of renders.

---
*PR created automatically by Jules for task [221582718607755863](https://jules.google.com/task/221582718607755863) started by @noahpengding*