### PR TITLE
🎨 Palette: Improve Chat dropdown menu accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-02-23 - Async Action Accessibility
 **Learning:** Form submit buttons without explicit loading state fail to communicate that background processing is happening, especially problematic for screen readers.
 **Action:** Always provide a clear loading state (e.g. SVG spinner) and update the `aria-label` (e.g. "Sending message...") to ensure feedback for interactive processes.
+
+## 2025-06-03 - Dropdown Menu Accessibility
+**Learning:** Custom dropdown menus created with simple `<div>` and `<button>` elements are not announced correctly by screen readers. They need explicit roles and states.
+**Action:** Always add `aria-haspopup="menu"` and `aria-expanded` to the toggle button, and `role="menuitem"` to the items inside the custom dropdown menu.

--- a/app/web/src/components/ChatInterface.tsx
+++ b/app/web/src/components/ChatInterface.tsx
@@ -329,6 +329,8 @@ const ChatbotUI = () => {
           type="button"
           className="menu-button"
           aria-label="Open menu"
+          aria-haspopup="menu"
+          aria-expanded={isMenuOpen}
           title="Menu"
           onClick={() => setIsMenuOpen((v) => !v)}
         >
@@ -340,18 +342,19 @@ const ChatbotUI = () => {
             role="menu"
             aria-label="Navigation Menu"
           >
-            <a href="/memory" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/memory" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               Memory
             </a>
-            <a href="/model" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/model" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               Model
             </a>
-            <a href="/rag" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/rag" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               RAG
             </a>
             <a
               href="https://us5.datadoghq.com/llm/applications?query=&fromUser=true&start=1770794053588&end=1770880453588&paused=false"
               className="menu-item external-link"
+              role="menuitem"
               target="_blank"
               rel="noreferrer"
               onClick={() => setIsMenuOpen(false)}
@@ -361,6 +364,7 @@ const ChatbotUI = () => {
             <a
               href="https://github.com/Noahdingpeng/peng-agent"
               className="menu-item external-link"
+              role="menuitem"
               target="_blank"
               rel="noreferrer"
               onClick={() => setIsMenuOpen(false)}


### PR DESCRIPTION
### 💡 What
Added missing ARIA attributes (`aria-haspopup="menu"`, `aria-expanded`) to the Chat UI's top-right menu toggle button, and explicitly marked all internal links with `role="menuitem"`.

### 🎯 Why
Custom dropdown menus created with simple `<div>` and `<button>` wrappers are not automatically interpreted as menus by screen readers, making navigation confusing or impossible. These explicit roles and states are required for the menu to be fully accessible and understandable to assistive technologies.

### 📸 Before/After
*(Visuals remain unchanged, but structural semantic meaning is now correct)*
See attached verified frontend video & screenshot demonstrating that the dropdown menu functionality continues to work visually exactly as intended.

### ♿ Accessibility
- Associated the toggle button with its popup menu nature using `aria-haspopup`.
- Connected the `isMenuOpen` state to the button via `aria-expanded`.
- Gave list children proper `menuitem` roles instead of just being raw links inside a menu div.

---
*PR created automatically by Jules for task [10895369354786446110](https://jules.google.com/task/10895369354786446110) started by @noahpengding*