### PR TITLE
🎨 Palette: [UX improvement] Enhance accessibility for popups and menus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-02-23 - Async Action Accessibility
 **Learning:** Form submit buttons without explicit loading state fail to communicate that background processing is happening, especially problematic for screen readers.
 **Action:** Always provide a clear loading state (e.g. SVG spinner) and update the `aria-label` (e.g. "Sending message...") to ensure feedback for interactive processes.
+
+## 2025-06-03 - Modal and Menu Accessibility
+**Learning:** Custom popups and menus often lack the ARIA attributes needed for screen reader accessibility, resulting in missing context.
+**Action:** Always add `role="dialog"` and `aria-modal="true"` to custom popups, and link their title using `aria-labelledby`. For custom dropdown menus, use `aria-expanded`, `aria-haspopup="menu"`, and `role="menuitem"` on the menu items.

--- a/app/web/src/components/ChatInterface.tsx
+++ b/app/web/src/components/ChatInterface.tsx
@@ -330,6 +330,8 @@ const ChatbotUI = () => {
           className="menu-button"
           aria-label="Open menu"
           title="Menu"
+          aria-expanded={isMenuOpen}
+          aria-haspopup="menu"
           onClick={() => setIsMenuOpen((v) => !v)}
         >
           …
@@ -340,18 +342,19 @@ const ChatbotUI = () => {
             role="menu"
             aria-label="Navigation Menu"
           >
-            <a href="/memory" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/memory" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               Memory
             </a>
-            <a href="/model" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/model" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               Model
             </a>
-            <a href="/rag" className="menu-item" onClick={() => setIsMenuOpen(false)}>
+            <a href="/rag" className="menu-item" role="menuitem" onClick={() => setIsMenuOpen(false)}>
               RAG
             </a>
             <a
               href="https://us5.datadoghq.com/llm/applications?query=&fromUser=true&start=1770794053588&end=1770880453588&paused=false"
               className="menu-item external-link"
+              role="menuitem"
               target="_blank"
               rel="noreferrer"
               onClick={() => setIsMenuOpen(false)}
@@ -361,6 +364,7 @@ const ChatbotUI = () => {
             <a
               href="https://github.com/Noahdingpeng/peng-agent"
               className="menu-item external-link"
+              role="menuitem"
               target="_blank"
               rel="noreferrer"
               onClick={() => setIsMenuOpen(false)}
@@ -534,9 +538,12 @@ const ChatbotUI = () => {
           <div
             className="popup-content"
             onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="tool-popup-title"
           >
             <div className="popup-header">
-              <h3>Select Tools</h3>
+              <h3 id="tool-popup-title">Select Tools</h3>
               <div className="popup-actions">
                 <button
                   className="update-button"

--- a/app/web/src/components/UserProfilePopup.tsx
+++ b/app/web/src/components/UserProfilePopup.tsx
@@ -116,9 +116,12 @@ const UserProfilePopup: React.FC<UserProfilePopupProps> = ({ isOpen, onClose, av
       <div
         className="popup-content user-profile-popup"
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="profile-popup-title"
       >
         <div className="popup-header">
-          <h3>User Profile</h3>
+          <h3 id="profile-popup-title">User Profile</h3>
           <div className="popup-actions">
             <button
               className="update-button"


### PR DESCRIPTION
💡 What: Added ARIA dialog roles to custom popups and ARIA menu roles to the custom dropdown.
🎯 Why: Custom `div`-based popups and menus are not automatically announced as dialogs or menus by screen readers. Adding these roles provides missing context.
📸 Before/After: No visual changes.
♿ Accessibility: Significant improvement for screen reader users interacting with the user profile, tool selection, and top navigation menu.

---
*PR created automatically by Jules for task [3211263149248737595](https://jules.google.com/task/3211263149248737595) started by @noahpengding*