### PR TITLE
🎨 Palette: [UX improvement] Improve memory selection table usability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-02-23 - Async Action Accessibility
 **Learning:** Form submit buttons without explicit loading state fail to communicate that background processing is happening, especially problematic for screen readers.
 **Action:** Always provide a clear loading state (e.g. SVG spinner) and update the `aria-label` (e.g. "Sending message...") to ensure feedback for interactive processes.
+
+## 2025-05-18 - Click Target Size for Table Actions
+**Learning:** Forcing users to click small checkboxes in data tables is poor usability. Making the entire row clickable provides a much larger hit area, adhering better to Fitts's Law.
+**Action:** Always make entire table rows clickable when they primarily function as a selection mechanism, taking care to prevent event bubbling issues from the inner inputs.

--- a/app/web/src/components/MemorySelection.tsx
+++ b/app/web/src/components/MemorySelection.tsx
@@ -118,9 +118,19 @@ const MemoryPage: React.FC = () => {
             <tbody>
               {filteredMemories.length > 0 ? (
                 filteredMemories.map((memory) => (
-                  <tr key={memory.id}>
+                  <tr
+                    key={memory.id}
+                    onClick={() => handleCheckboxChange(memory.id)}
+                    style={{ cursor: 'pointer' }}
+                  >
                     <td>
-                      <input type="checkbox" checked={selectedMemoryIds.includes(memory.id)} onChange={() => handleCheckboxChange(memory.id)} aria-label={`Select memory ${memory.id}`} />
+                      <input
+                        type="checkbox"
+                        checked={selectedMemoryIds.includes(memory.id)}
+                        onChange={() => handleCheckboxChange(memory.id)}
+                        onClick={(e) => e.stopPropagation()}
+                        aria-label={`Select memory: ${truncateText(memory.human_input, 50)}`}
+                      />
                     </td>
                     <td>{memory.base_model}</td>
                     <td title={memory.human_input}>{truncateText(memory.human_input, 600)}</td>
@@ -129,7 +139,7 @@ const MemoryPage: React.FC = () => {
                 ))
               ) : (
                 <tr>
-                  <td colSpan={5} className="no-memories">
+                  <td colSpan={4} className="no-memories">
                     {searchTerm ? 'No memories match your search' : 'No memories available'}
                   </td>
                 </tr>


### PR DESCRIPTION
💡 **What:** 
- Made the entire row in the Memory Selection table clickable to toggle selection, instead of requiring users to click the tiny checkbox.
- Fixed a subtle bug in the empty state where `colSpan=5` was used instead of `colSpan=4` (matching the 4 columns).

🎯 **Why:** 
- Clicking a small checkbox is difficult and frustrating. Applying Fitts's Law by making the entire row the click target vastly improves usability.

📸 **Before/After:**
- Before: Only the 16x16 pixel checkbox was clickable. Opaque ID in ARIA label.
- After: The entire table row is clickable. Checkbox ARIA label reads contextually (e.g., "Select memory: What is the meaning of life?").

♿ **Accessibility:** 
- Upgraded the checkbox's `aria-label` from a meaningless UUID hash to a truncated preview of the `human_input` being selected. Screen reader users now know exactly what memory they are interacting with.

---
*PR created automatically by Jules for task [12338540739189859204](https://jules.google.com/task/12338540739189859204) started by @noahpengding*